### PR TITLE
Add optional name filter

### DIFF
--- a/homekit.js
+++ b/homekit.js
@@ -225,10 +225,12 @@ module.exports = function (RED) {
         return;
       }
 
-      if(msg.payload.hasOwnProperty('name')) {
-        if(msg.payload.name !== node.name) {
-          node.debug('Skipping message sent to another node ' + msg.payload.name)
+      if(msg.payload.hasOwnProperty('Name')) {
+        if(msg.payload.Name !== node.name) {
+          node.debug('Skipping message sent to another node ' + msg.payload.Name)
+          return;
         }
+        delete msg.payload.Name;
       }
 
       var context = null;

--- a/homekit.js
+++ b/homekit.js
@@ -13,7 +13,7 @@ module.exports = function (RED) {
     this.getCharacteristic(name).setValue(value, null, context);
     return this; // for chaining
   }
-  
+
   // Initialize our storage system
   if (RED.settings.available()) {
     var userDir = RED.settings.userDir;
@@ -224,13 +224,19 @@ module.exports = function (RED) {
         node.warn('Invalid message (payload missing)');
         return;
       }
-      
+
+      if(msg.payload.hasOwnProperty('name')) {
+        if(msg.payload.name !== node.name) {
+          node.debug('Skipping message sent to another node ' + msg.payload.name)
+        }
+      }
+
       var context = null;
       if (msg.payload.hasOwnProperty('Context')) {
         context = msg.payload.Context;
         delete msg.payload.Context;
       }
-      
+
       // iterate over characteristics to be written
       Object.keys(msg.payload).map(function (key, index) {
         if (supported.write.indexOf(key) < 0) {


### PR DESCRIPTION
I had the idea of trying to make it easier to do many accessories without having to build big switches, but rather by some kind of conventions. This is my initial idea, so let me know what you think.

The description of the pull request additions to the system is

> Add a name filter to help out sending input messages to multiple accessories.
> The filter is only activated if a msg.payload.name is present. The name should
> be exactly the same as the one sent outgoing messages.
> I the msg.payload.name is not present then the message is handled like normal.

Also, love the improvements you made to the homekit plugin, including adding the name to output messages and making it easier to do many accessories 👍 