### PR TITLE
Fixes PM2.5 characteristics

### DIFF
--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -112,7 +112,7 @@ module.exports = function(RED) {
     // emit message when value changes
     service.on("characteristic-change", function(info) {
       var msg = { payload: {}, hap: info, name: node.name };
-      var key = info.characteristic.displayName.replace(/ /g, "");
+      var key = info.characteristic.displayName.replace(/ /g, '').replace(/\./g, '_');
       msg.payload[key] = info.newValue;
       node.status({
         fill: "yellow",
@@ -130,7 +130,7 @@ module.exports = function(RED) {
       service.optionalCharacteristics
     );
     allCharacteristics.map(function(characteristic, index) {
-      var cKey = characteristic.displayName.replace(/ /g, "");
+      var cKey = characteristic.displayName.replace(/ /g, '').replace(/\./g, '_');
       if (characteristic.props.perms.indexOf("pw") > -1) {
         supported.read.push(cKey);
       }


### PR DESCRIPTION
This PR should fix the issue that PM2.5 characteristics can't be added to AirQuality Sensor.

Prior to this, it didn't recognize the characteristics. With this pull you can add it as 'PM2_5Density'.
