### PR TITLE
"No response" status can now be programmatically triggered

### DIFF
--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -218,6 +218,14 @@ module.exports = function(RED) {
               supported.write.join(", ")
           );
         } else {
+          var noResponseMsg = "NO_RESPONSE";
+            
+          if (msg.payload[key] === noResponseMsg) {
+            service.setCharacteristic(Characteristic[key], new Error(noResponseMsg));
+
+            return;
+          }
+          
           if (context !== null) {
             service.setCharacteristicWithContext(
               Characteristic[key],


### PR DESCRIPTION
No response status can be triggered via sending NO_RESPONSE as a value of some valid characteristic. #48 