### PR TITLE
Disables accessory control when NO_RESPONSE was triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ Context info can be provided as part of the input message and will be available 
 }
 ```
 
+## No Response
+
+You can set accessory "No Response" status by sending "NO_RESPONSE" as a value for any available characteristic.
+
+**Example**:
+
+```json
+{
+  "On": "NO_RESPONSE"
+}
+```
+
+After "No Response" status was triggered, the accessory is marked accordingly when you try to control it or reopen Home.app.
+Any subsequent update of any characteristic value will reset this status.
+
 ## FAQ
 
 #### How can I generate Debug logs?

--- a/homekit.html
+++ b/homekit.html
@@ -265,7 +265,11 @@
                 required: false
             },
             name: {
-                value: ""
+                value: "",
+                required: true,
+                validate: function(value) {
+                    return value.length > 0;
+                }
             },
             serviceName: {
                 value: "",
@@ -275,7 +279,7 @@
                 value:""
             },
             filter: {
-                value:false
+                value: false
             },
             manufacturer: {
                 value: "Default Manufacturer",

--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -97,16 +97,6 @@ module.exports = function(RED) {
         // Which characteristics are supported?
         this.supported = CharacteristicUtils.getSupported(service);
 
-        this.supported.write.forEach(function(item) {
-            const characteristic = service.getCharacteristic(item);
-
-            if (characteristic) {
-                characteristic.on("set", function(newVal, callback) {
-                    callback(node.accessory.reachable === false ? "no response" : null);
-                });
-            }
-        });
-
         // Respond to inputs
         this.on("input", ServiceUtils.onInput);
 

--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -95,7 +95,7 @@ module.exports = function(RED) {
         service.on("characteristic-change", ServiceUtils.onCharacteristicChange);
 
         // Which characteristics are supported?
-        this.supported = CharacteristicUtils.getSupported(service);
+        this.supported = CharacteristicUtils.getSupportedAndSubscribeSet(service);
 
         // Respond to inputs
         this.on("input", ServiceUtils.onInput);

--- a/lib/HAPServiceNode.js
+++ b/lib/HAPServiceNode.js
@@ -97,6 +97,16 @@ module.exports = function(RED) {
         // Which characteristics are supported?
         this.supported = CharacteristicUtils.getSupported(service);
 
+        this.supported.write.forEach(function(item) {
+            const characteristic = service.getCharacteristic(item);
+
+            if (characteristic) {
+                characteristic.on("set", function(newVal, callback) {
+                    callback(node.accessory.reachable === false ? "no response" : null);
+                });
+            }
+        });
+
         // Respond to inputs
         this.on("input", ServiceUtils.onInput);
 

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -27,7 +27,7 @@ module.exports = function(node) {
         return characteristicProperties;
     };
 
-    const getSupported = function (service) {
+    const getSupportedAndSubscribeSet = function (service) {
         const supported = {read: [], write: []};
 
         const allCharacteristics = service.characteristics.concat(
@@ -66,6 +66,6 @@ module.exports = function(node) {
 
     return {
         load: load,
-        getSupported: getSupported
+        getSupportedAndSubscribeSet: getSupportedAndSubscribeSet
     };
 };

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -40,6 +40,15 @@ module.exports = function(node) {
                 .replace(/\./g, "_");
             if (characteristic.props.perms.indexOf("pw") > -1) {
                 supported.read.push(cKey);
+
+                // Subscribe to 'get' event of readable characteristic
+                characteristic.on("get", function(callback, context) {
+                    if (node.accessory.reachable === true) {
+                        callback(null, characteristic.value);
+                    } else {
+                        callback("no response", null);
+                    }
+                });
             }
 
             if (

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -60,7 +60,7 @@ module.exports = function(node) {
                 
                 // Subscribe to 'set' event of writable characteristic
                 characteristic.on("set", function(newVal, callback) {
-                    callback(node.accessory.reachable === false ? "no response" : null);
+                    callback(node.accessory.reachable === true ? null : "no response");
                 });
             }
 

--- a/lib/utils/CharacteristicUtils.js
+++ b/lib/utils/CharacteristicUtils.js
@@ -48,6 +48,11 @@ module.exports = function(node) {
                 -2
             ) {
                 supported.write.push(cKey);
+                
+                // Subscribe to 'set' event of writable characteristic
+                characteristic.on("set", function(newVal, callback) {
+                    callback(node.accessory.reachable === false ? "no response" : null);
+                });
             }
 
             //Allow for negative temperatures

--- a/lib/utils/ServiceUtils.js
+++ b/lib/utils/ServiceUtils.js
@@ -67,10 +67,13 @@ module.exports = function(node) {
                 const noResponseMsg = "NO_RESPONSE";
 
                 if (msg.payload[key] === noResponseMsg) {
+                    node.accessory.updateReachability(false);
                     characteristic.setValue(new Error(noResponseMsg));
 
                     return;
                 }
+
+                node.accessory.updateReachability(true);
 
                 if (context !== null) {
                     characteristic.setValue(msg.payload[key], undefined, context);


### PR DESCRIPTION
Here is the improvement of NO_RESPONSE implementation. If NO_RESPONSE was triggered and Home.app was not reopened, user still can control device as described here https://github.com/oliverrahner/node-red-contrib-homekit-bridged/issues/48. The improvement fixes this undesired behavior.